### PR TITLE
make the returned readable stream async

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,10 @@ function StreamArray(list) {
 StreamArray.prototype = Object.create(Readable.prototype, {constructor: {value: StreamArray}});
 
 StreamArray.prototype._read = function(size) {
-    this.push(this._i < this._l ? this._list[this._i++] : null);
+    var self = this;
+    process.nextTick(function() {
+        self.push(self._i < self._l ? self._list[self._i++] : null);
+    });
 };
 
 module.exports = function(list) {

--- a/test/5.js
+++ b/test/5.js
@@ -1,0 +1,27 @@
+var test = require('tape')
+    , streamify = require('..')
+    , concat = require('concat-stream')
+;
+
+test('async, non-blocking', function(t) {
+    var s = streamify(['1', '2', '3']);
+
+    var i = 0;
+    s.on('data', function(item) {
+      i++;
+    });
+
+    process.nextTick(function() {
+      t.ok(i === 0 || i === 1, 'should have emitted one item at most in the first tick');
+      process.nextTick(function() {
+        t.ok(i === 1 || i === 2, 'should have emitted one or two items in the second tick');
+        process.nextTick(function() {
+          t.ok(i === 2 || i === 3, 'should have emitted two or three items in the thrid tick');
+          process.nextTick(function() {
+            t.equal(3, i, 'should have emitted all three items in the fourth tick');
+            t.end();
+          });
+        });
+      });
+    });
+});

--- a/test/5.js
+++ b/test/5.js
@@ -12,11 +12,11 @@ test('async, non-blocking', function(t) {
     });
 
     process.nextTick(function() {
-      t.ok(i === 0 || i === 1, 'should have emitted one item at most in the first tick');
+      t.equal(0, i, 'should emit the first item after this code');
       process.nextTick(function() {
-        t.ok(i === 1 || i === 2, 'should have emitted one or two items in the second tick');
+        t.equal(1, i, 'should emit the second item after this code');
         process.nextTick(function() {
-          t.ok(i === 2 || i === 3, 'should have emitted two or three items in the thrid tick');
+          t.equal(2, i, 'should emit the third item after this code');
           process.nextTick(function() {
             t.equal(3, i, 'should have emitted all three items in the fourth tick');
             t.end();


### PR DESCRIPTION
Most, if not all streams are asynchronous, this one is not. If a big array is used it is streamed completely in the same tick and blocks all other events until it has fired all data events.

This patch makes this module operate asynchronous like other streams.
